### PR TITLE
Haxe themed flambe skin

### DIFF
--- a/themes/flambe/resources/styles.css
+++ b/themes/flambe/resources/styles.css
@@ -1,4 +1,5 @@
-/* .navbar { position:static !important; margin:0px !important;} */
+.navbar { margin:0 0 20px 0; padding:2px 10px; background:#000; color:#fff; } 
+.navbar .tagline { position:relative; top:11px; } 
 
 /* #nav { */
 /*   float: left; */
@@ -8,6 +9,12 @@
 /*#content .header { position:absolute; background:rgba(255,255,255,0.9); left:250px; right:15px; padding:0px 12px; border-bottom:1px solid #EEE;}*/
 /*#content .body { padding-top:80px;}*/
 
+a.treeLink { color: #F48821; }
+a.treeLink:hover { color: #9F5409; }
+.nav-list>.active>a.treeLink, .nav-list>.active>a.treeLink:hover, .nav-list>.active>a.treeLink:focus {
+	background:#F48821;
+	color:#fff;
+}
 /* .doc { margin-top:16px; } */
 .toggle-hide { display:block; }
 .toggle-show { display:none; }
@@ -68,7 +75,40 @@ code .type { color:#268bd2; }
 /* .navbar-fixed-bottom .navbar-inner { padding: 0; } */
 
 body {
-  padding-top: 20px;
+  padding: 0px;
+  font-size:16px;
+  font-family:"Open Sans", sans-serif;
+  color: #1e1e1e;
+  line-height: 1.5;
+}
+
+h1, h2, h3, h4, h5, h6 {
+	font-family: "Source Sans Pro", sans-serif;
+	font-weight: 600;
+}
+h1 {
+	font-size: 36px;
+	color: #171717;
+}
+h1 small {
+	font-size: 14px;
+	color: #999;
+	font-weight: normal;
+}
+h2 {
+	font-size: 30px;
+}
+h3 {
+	font-size: 24px;
+}
+h4 {
+	font-size: 20px;
+}
+h5, h5 code {
+	font-size: 18px;
+}
+h6 {
+	font-size: 16px;
 }
 
 .sidebar-nav {
@@ -84,12 +124,16 @@ body {
 }
 
 .indent {
-  margin-left: 40px;
+  margin-left: 20px;
+  border-left: 5px solid #eeeeee;
+  padding-left:20px;
 }
 
 .doc-main {
   margin-bottom: 40px;
 }
+
+.doc-main p { font-style: italic; }
 
 .section {
   border-bottom: 1px solid #eee;

--- a/themes/flambe/resources/styles.css
+++ b/themes/flambe/resources/styles.css
@@ -1,5 +1,6 @@
-.navbar { margin:0 0 20px 0; padding:2px 10px; background:#000; color:#fff; } 
+.navbar { margin:0 0 20px 0; padding:0; background:#000; color:#fff; } 
 .navbar .tagline { position:relative; top:11px; } 
+.navbar .brand { padding: 7px 20px 7px;}
 
 /* #nav { */
 /*   float: left; */

--- a/themes/flambe/templates/main.mtt
+++ b/themes/flambe/templates/main.mtt
@@ -4,6 +4,8 @@
 	<meta charset='utf-8'/>
 	<link href="::api.config.rootPath::bootstrap/css/bootstrap.min.css" rel="stylesheet" />
 	<link href="::api.config.rootPath::bootstrap/css/bootstrap-responsive.min.css" rel="stylesheet" />
+	<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,700,700italic,400italic' rel='stylesheet' type='text/css'/>
+	<link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:200,600,600italic,400' rel='stylesheet' type='text/css'/>
 	<script src="::api.config.rootPath::jquery-1.9.1.min.js"></script>
 	<script src="::api.config.rootPath::bootstrap/js/bootstrap.min.js"></script>
 	<link href="::api.config.rootPath::styles.css" rel="stylesheet" />
@@ -22,6 +24,14 @@
 	<title>::api.currentPageName::::if api.config.pageTitle !=null:: - ::api.config.pageTitle::::end::</title>
 </head>
 <body>
+        <nav class="navbar navbar-static-top" role="navigation">
+          <div class="container">
+	   <div class="navbar-header">
+	    <a class="brand" href="/"><img src="http://haxe.org/img/haxe-logo-horizontal-on-dark.svg" width="107" height="21" alt="Haxe" onerror="this.src='http://haxe.org/img/haxe-logo-horizontal-on-dark.png'"/></a>
+	    <span class="tagline">API documentation</span>
+	   </div>
+	  </div>
+	</nav>
 	<div class="container">
         <div class="row-fluid">
             <div class="span3">


### PR DESCRIPTION
I really like the flambe theme, it should be the standard for the haxe api docs. That's why I updated it and added some recognizable elements to make it a bit more in line with haxe.org styles.

![update-theme](https://cloud.githubusercontent.com/assets/576184/5481345/2f76287a-8650-11e4-9353-ba6461c403eb.png)