### PR TITLE
Improve enum output in 'flambe' theme

### DIFF
--- a/themes/flambe/templates/enum.mtt
+++ b/themes/flambe/templates/enum.mtt
@@ -15,7 +15,7 @@
 		</div>
 		::if type.constructors.length > 0::
             <h3 class="section">Values</h3>
-            <div class="field">
+            <div class="fields">
                 ::foreach ctor type.constructors::
                     ::use "enum_field.mtt"::::end::
                 ::end::

--- a/themes/flambe/templates/enum_field.mtt
+++ b/themes/flambe/templates/enum_field.mtt
@@ -1,13 +1,15 @@
-<h3>
-	<code>
-		<a name="::ctor.name::" href="#::ctor.name::">
-			<span class="identifier">::ctor.name::</span>
-		</a>
-        ::if ctor.args != null::
-            (::foreach arg ctor.args::::arg.name:: :$$printLinkedType(::arg.t::)::if !repeat.arg.last::, ::end::::end::)
-        ::end::
-	</code>
-</h3>
-<div class="doc" ::cond ctor.doc != null::>
-	::raw ctor.doc::
+<div class="field">
+	<h3>
+		<code>
+			<a name="::ctor.name::" href="#::ctor.name::">
+				<span class="identifier">::ctor.name::</span>
+			</a>
+	        ::if ctor.args != null::
+	            (::foreach arg ctor.args::::arg.name:::$$printLinkedType(::arg.t::)::if !repeat.arg.last::, ::end::::end::)
+	        ::end::
+		</code>
+	</h3>
+	<div class="doc" ::cond ctor.doc != null::>
+		::raw ctor.doc::
+	</div>
 </div>


### PR DESCRIPTION
This resolves some apparent issues in how enums were being presented.

The properties, methods and other values using a `<div class="fields"><div class="field"></div></div>` hierarchy, but enum values used only `<div class="field" />`, so the indentation looked very different. I also removed a space that was presenting `myvalue :MyValueType` in enum constructors, rather than `myvalue:MyValueType` which looks nicer.

It's all aesthetic, but it's a step forward, I think :smile: