### PR TITLE
small style change to haxe-api theme

### DIFF
--- a/themes/haxe-api/resources/index.js
+++ b/themes/haxe-api/resources/index.js
@@ -10,9 +10,9 @@ function toggleInherited(el) {
 	var toggle = $(el).closest(".toggle");
 	toggle.toggleClass("toggle-on");
 	if (toggle.hasClass("toggle-on")) {
-		$("img", toggle).attr("src", dox.rootPath + "triangle-opened.png");
+		$("i", toggle).removeClass("fa-arrow-circle-o-right").addClass("fa-arrow-circle-o-down");
 	} else {
-		$("img", toggle).attr("src", dox.rootPath + "triangle-closed.png");
+		$("i", toggle).addClass("fa-arrow-circle-o-right").removeClass("fa-arrow-circle-o-down");
 	}
     return false;
 }
@@ -22,9 +22,9 @@ function toggleCollapsed(el) {
 	toggle.toggleClass("expanded");
 
 	if (toggle.hasClass("expanded")) {
-		$("img", toggle).first().attr("src", dox.rootPath + "triangle-opened.png");
+		$("i", toggle).removeClass("fa-arrow-circle-o-right").addClass("fa-arrow-circle-o-down");
 	} else {
-		$("img", toggle).first().attr("src", dox.rootPath + "triangle-closed.png");
+		$("i", toggle).addClass("fa-arrow-circle-o-right").removeClass("fa-arrow-circle-o-down");
 	}
 	updateTreeState();
     return false;
@@ -103,7 +103,7 @@ $(document).ready(function(){
 	var treeState = readCookie("treeState");
 
 	$("#nav .expando").each(function(i, e){
-		$("img", e).first().attr("src", dox.rootPath + "triangle-closed.png");
+		$("i", e).first().removeClass("fa-arrow-circle-o-right").addClass("fa-arrow-circle-o-down");
 	});
 
 	$(".treeLink").each(function() {
@@ -116,7 +116,7 @@ $(document).ready(function(){
 		$("#nav .expando").each(function(i, e){
 			if (states[i]) {
 				$(e).addClass("expanded");
-				$("img", e).first().attr("src", dox.rootPath + "triangle-opened.png");
+				$("i", e).first().addClass("fa-arrow-circle-o-right").removeClass("fa-arrow-circle-o-down");
 			}
 		});
 	}

--- a/themes/haxe-api/resources/index.js
+++ b/themes/haxe-api/resources/index.js
@@ -103,7 +103,7 @@ $(document).ready(function(){
 	var treeState = readCookie("treeState");
 
 	$("#nav .expando").each(function(i, e){
-		$("i", e).first().removeClass("fa-arrow-circle-o-right").addClass("fa-arrow-circle-o-down");
+		$("i", e).first().addClass("fa-arrow-circle-o-right").removeClass("fa-arrow-circle-o-down");
 	});
 
 	$(".treeLink").each(function() {
@@ -116,7 +116,7 @@ $(document).ready(function(){
 		$("#nav .expando").each(function(i, e){
 			if (states[i]) {
 				$(e).addClass("expanded");
-				$("i", e).first().addClass("fa-arrow-circle-o-right").removeClass("fa-arrow-circle-o-down");
+				$("i", e).first().removeClass("fa-arrow-circle-o-right").addClass("fa-arrow-circle-o-down");
 			}
 		});
 	}

--- a/themes/haxe-api/resources/styles.css
+++ b/themes/haxe-api/resources/styles.css
@@ -34,11 +34,19 @@
 /*#content .body { padding-top:80px;}*/
 .nav-list {padding-right: 0;	 }
 .nav-list>li>a, .nav-list .nav-header {margin-right:0;}
+.nav-list>li>a.treeLink {padding-left:20px;}
 .nav-list a { word-wrap: break-word; font-size:14px; text-shadow: none!important;}
 .nav-list>.active>a.treeLink, .nav-list>.active>a.treeLink:hover, .nav-list>.active>a.treeLink:focus {
 	background:#F48821;
 	color:#fff;
+}
 
+.nav-list li i.fa {
+	height: 16px;
+	width: 16px;
+	color: rgb(200,200,200);
+	font-weight:normal;
+	font-size:16px;
 }
 
 .viewsource {float:right}
@@ -91,7 +99,13 @@ footer{
 }
 
 /* h1 code { padding:4px; font-size:15px; } */
-/* h3 code { padding:4px; font-size:13px; } */
+h3 code { 
+	box-shadow: 0 0 15px rgb(240, 240, 240);
+	padding: 4px 8px; 
+}
+
+h3 p { margin-left: -20px; }
+
 code {
   font-family: Monaco,Menlo,Consolas,"Courier New",monospace;
   font-weight: normal;

--- a/themes/haxe-api/resources/styles.css
+++ b/themes/haxe-api/resources/styles.css
@@ -104,7 +104,7 @@ h3 code {
 	padding: 4px 8px; 
 }
 
-h3 p { margin-left: -20px; }
+h3 p { margin-left: -10px; }
 
 code {
   font-family: Monaco,Menlo,Consolas,"Courier New",monospace;

--- a/themes/haxe-api/templates/main.mtt
+++ b/themes/haxe-api/templates/main.mtt
@@ -6,6 +6,7 @@
 	<link href="::api.config.rootPath::bootstrap/css/bootstrap-responsive.min.css" rel="stylesheet" />
 	<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,700,700italic,400italic' rel='stylesheet' type='text/css'/>
 	<link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:200,600,600italic,400' rel='stylesheet' type='text/css'/>
+	<link href='http://netdna.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.css' rel='stylesheet' type='text/css' />
 	
 	<script src="::api.config.rootPath::jquery-1.9.1.min.js"></script>
 	<script src="::api.config.rootPath::bootstrap/js/bootstrap.min.js"></script>

--- a/themes/haxe-api/templates/nav.mtt
+++ b/themes/haxe-api/templates/nav.mtt
@@ -1,7 +1,7 @@
 <macro name="makeTree(tree,depth)">
 	::switch tree::
 	<li ::attr data_path api.getTreePath(tree)::>
-        <a class="treeLink" href="::api.getTreeUrl(tree)::">
+        <a class="treeLink" href="::api.getTreeUrl(tree)::" title=":: api.getTreePack(tree) + api.getTreeName(tree) ::">
             <span class="pack">:: api.getTreePack(tree) ::</span>::api.getTreeName(tree)::
         </a>
 	</li>
@@ -10,7 +10,7 @@
 		<li ::cond name.charAt(0) != "_"::
 			::attr class "expando" +if (depth == 0 && api.isPlatform(name)) " platform platform-" + name else ""::>
             <a class="nav-header" href="#" onclick="return toggleCollapsed(this)">
-                <img src="::api.config.rootPath::/triangle-closed.png"/>
+		<i class="fa fa-arrow-circle-o-right"></i>
                 ::api.getTreeName(tree)::
             </a>
 			<ul class="nav nav-list">


### PR DESCRIPTION
* code titles stand out a bit more (bit indenting change + padding + shadow)
* awesomefont icons in menubar, more in line with manual

![haxe-api-theme-update](https://cloud.githubusercontent.com/assets/576184/6135827/05f7ce62-b16c-11e4-8e91-4f39f9768e80.png)

Sorry this should have been in previous PR.