### PR TITLE
Improved titles

### DIFF
--- a/themes/haxe-api/resources/styles.css
+++ b/themes/haxe-api/resources/styles.css
@@ -104,13 +104,19 @@ footer{
 	font-size: 90%;
 }
 
-/* h1 code { padding:4px; font-size:15px; } */
 h3 code { 
+	background:none;
 	box-shadow: 0 0 15px rgb(240, 240, 240);
-	padding: 4px 8px; 
+	padding: 4px 8px;
+	white-space: inherit;
+	display: inline-block;
+	line-height: 1.5em;
+	margin-left: -10px;
 }
 
-h3 p { margin-left: -10px; }
+h3 span.label {	
+	margin-right: 5px; 
+}
 
 code {
   font-family: Monaco,Menlo,Consolas,"Courier New",monospace;
@@ -123,6 +129,13 @@ code {
   padding: 2px 4px;
   font-size: 13px;
 }
+
+code .identifier {
+  font-family:bold 14px "Helvetica Neue",Helvetica,Arial,sans-serif;
+  color:#002b36;
+  padding: 0 0 0 5px;  
+}
+
 code .identifier, code.type {
   font-weight: bold;
 }
@@ -132,7 +145,6 @@ code a { text-decoration:none; }
 code a:hover { text-decoration:underline; }
 
 /*code.dark { background:#272822; color:#F8F8F2; border:none; } */
-code .identifier { color:#002b36; }
 code .type { color:#268bd2; }
 /* code .keyword { color:#dc322f; } */
 /* code .directive { color:#2aa198; } */

--- a/themes/haxe-api/templates/macros.mtt
+++ b/themes/haxe-api/templates/macros.mtt
@@ -43,10 +43,10 @@
 	::case::$$printLinkedPath(::args[0]::,::args[1]::)
 	::case::
 		::if args[0].length == 0::
-			$$printLinkedPath(::"Void"::,::[]::) -&gt;&nbsp;
+			$$printLinkedPath(::"Void"::,::[]::)&nbsp;&#8209;&gt;&nbsp;
 		::else::
 			::foreach arg args[0]::
-				$$printLinkedType(::arg.t::) -&gt;&nbsp;
+				$$printLinkedType(::arg.t::)&nbsp;&#8209;&gt;&nbsp;
 			::end::
 		::end::
 		$$printLinkedType(::args[1]::)
@@ -69,6 +69,7 @@
 </macro>
 
 <macro name="printFieldSignature(field, isStatic)">
+	<code>
 	::if isStatic::
 		<span class="label">static</span>
 	::end::
@@ -93,12 +94,9 @@
             <span class="label">write only</span>
         ::end::
 
-        <code>
-		<a href="#::field.name::"><span class="identifier">::field.name::</span></a>:$$printLinkedType(::field.type::)$$printInitExpr(::field.expr::)
-        </code>
+	<a href="#::field.name::"><span class="identifier">::field.name::</span></a>:$$printLinkedType(::field.type::)$$printInitExpr(::field.expr::)
 
 	::case 4::
-        <code>
 		<a href="#::field.name::"><span class="identifier">::field.name::</span></a>
 		$$printTypeParams(::field.params::) (
 		::foreach arg args[0]::
@@ -111,8 +109,8 @@
 		::if field.name != "new"::
 			:$$printLinkedType(::args[1]::)
 		::end::
-        </code>
 	::end::
+	</code>
 </macro>
 
 <macro name="printInitExpr(expr)">


### PR DESCRIPTION
* Break long parameters on functions, avoid horizontal scroll
* Non-breaking hyphen for `->` in parameters
* Labels in `<code>`
* Break long parameters on functions, avoid horizontal scroll
* Different font for identifier
* Space in-between labels