### PR TITLE
Fix line breaks between arguments and commas

### DIFF
--- a/test/TestClass.hx
+++ b/test/TestClass.hx
@@ -141,6 +141,13 @@ class TestClass
 	}
 
 	/**
+		There should not be a line break between `,` and `Looped`.
+	**/
+	public function addByIndices(Name:String, Prefix:String, Indices:Array<Int>, Postfix:String, VeryVeryVeryLongArgumentName:Int = 30, Looped:Bool = true):Void
+	{
+	}
+
+	/**
 		Should be in the "variables" section as `callback:String -> Int -> Void`.
 	**/
 	public var callback:String->Int->Void;

--- a/themes/default/templates/macros.mtt
+++ b/themes/default/templates/macros.mtt
@@ -108,8 +108,9 @@
 				::if arg.opt && (arg.value == null || arg.value == "null")::?::end::
 				::arg.name:::$$printLinkedType(::arg.t::)
 				::if arg.value != null && arg.value != "null":: = ::arg.value::::end::
+				::if !repeat.arg.last::,::end::
 			</span>
-			::if !repeat.arg.last::, ::end::
+			::if !repeat.arg.last:: ::end::
 		::end::
 		)
 		::if field.name != "new"::


### PR DESCRIPTION
Forgot about the comma in #151, which leads to issues like this:

![](http://i.imgur.com/eXhnOIL.png)