### PR TITLE
Readme: update OpenFL API link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 A Haxe documentation generator used by many popular projects such as:
 
 - [Haxe](http://api.haxe.org/)
-- [OpenFL](http://www.openfl.org/documentation/api/)
+- [OpenFL](http://api.openfl.org/)
 - [HaxeUI](http://haxeui.org/docs/api/haxe/ui/toolkit/index.html)
 - [HaxeFlixel](http://api.haxeflixel.com/)
 - [HaxePunk](http://haxepunk.com/documentation/api/)


### PR DESCRIPTION
http://api.openfl.org/ is a more updated version of OpenFL's docs, though http://www.openfl.org/documentation/api/ is still around for some reason.